### PR TITLE
Fix/Preset for the Meteor65 Pro 2022 edition

### DIFF
--- a/config/presets-dist.scad
+++ b/config/presets-dist.scad
@@ -88,7 +88,7 @@ presets = [
         66,                     // IDX_MOTOR_DISTANCE
         40,                     // IDX_DUCT_DIAMETER
         17,                     // IDX_DUCT_HEIGHT
-        40,                     // IDX_WHOOP_HEIGHT
+        38,                     // IDX_WHOOP_HEIGHT
         5,                      // IDX_BOX_PADDING
         false,                  // IDX_BOX_SEPARATOR
         2,                      // IDX_BOX_X


### PR DESCRIPTION
Fix the preset for the Meteor65 Pro 2022 edition: the height was too high, leading the whoop to jump off its slot when the box is placed vertically.